### PR TITLE
Fix SFC table scrolling

### DIFF
--- a/client/src/components/SegmentFolioCuts.jsx
+++ b/client/src/components/SegmentFolioCuts.jsx
@@ -967,8 +967,10 @@ const SegmentFolioCuts = () => {
           `}</style>
         </div>
       ) : selectedSegment && filteredDetails.length > 0 ? (
-        <div style={{ 
+        <div style={{
           overflowX: 'auto',
+          overflowY: 'auto',
+          maxHeight: '70vh',
           boxShadow: '0 4px 12px rgba(0,0,0,0.08)',
           borderRadius: '10px',
           marginTop: '20px',


### PR DESCRIPTION
## Summary
- show SFC table horizontal scrollbar without scrolling to the bottom by limiting the table container height and enabling vertical scrolling

## Testing
- `npm run lint --prefix client` *(fails: Cannot find package '@eslint/js')*
- `npm run build --prefix client` *(fails: vite not found)*